### PR TITLE
sup-687 downgrading the min iOS version from 15 to 14

### DIFF
--- a/Package.swift
+++ b/Package.swift
@@ -6,10 +6,7 @@ import PackageDescription
 let package = Package(
     name: "Gowit",
     platforms: [
-        .iOS("15.0"),
-        .macOS("12.00"),
-        .tvOS("11.0"),
-        .watchOS("7.1")
+        .iOS("14.0")
     ],
     products: [
         // Products define the executables and libraries a package produces, making them visible to other packages.

--- a/README.md
+++ b/README.md
@@ -21,7 +21,7 @@ Add the following dependency to your `Package.swift` file:
 
 ```swift
 dependencies: [
-    .package(url: "https://github.com/gowittechnology/gowit-swift.git", from: "1.0.1")
+    .package(url: "https://github.com/gowittechnology/gowit-swift.git", from: "1.0.2")
 ]
 ```
 
@@ -723,7 +723,7 @@ Conditional rendering component that only shows when ads are available.
 
 ## Requirements
 
-- iOS 15.0+
+- iOS 14.0+
 - Swift 5.5+
 
 ## Support

--- a/Sources/AdViews/SponsoredDisplayView.swift
+++ b/Sources/AdViews/SponsoredDisplayView.swift
@@ -142,55 +142,58 @@ public struct AdImageView: View {
     public var body: some View {
         Group {
             if let imgUrl = ad.imgUrl, let url = URL(string: imgUrl) {
-                AsyncImage(url: url) { phase in
-                    switch phase {
-                    case .empty:
-                        // Placeholder that maintains layout
-                        Rectangle()
-                            .fill(Color.clear)
-                            .aspectRatio(16/9, contentMode: .fit) // Default aspect ratio
-                    case .success(let image):
-                        image
-                            .resizable()
-                            .aspectRatio(contentMode: .fit)
-                    case .failure:
-                        // Error state that maintains layout
-                        Rectangle()
-                            .fill(Color.gray.opacity(0.3))
-                            .aspectRatio(16/9, contentMode: .fit)
-                    @unknown default:
-                        Rectangle()
-                            .fill(Color.clear)
-                            .aspectRatio(16/9, contentMode: .fit)
-                    }
-                }
-                .onAppear {
-                    if !hasReportedImpression {
-                        reportImpression()
-                    }
-                }
-                .onTapGesture {
-                    if isClickable {
-                        reportClick()
-                        if let redirectUrl = ad.redirect?.url, let url = URL(string: redirectUrl) {
-                            #if os(iOS) || os(tvOS)
-                            UIApplication.shared.open(url)
-                            #elseif os(macOS)
-                            NSWorkspace.shared.open(url)
-                            #endif
+                if #available(iOS 15, *) {
+                    AsyncImage(url: url) { phase in
+                        switch phase {
+                        case .empty:
+                            // Placeholder that maintains layout
+                            Rectangle()
+                                .fill(Color.clear)
+                                .aspectRatio(16/9, contentMode: .fit) // Default aspect ratio
+                        case .success(let image):
+                            image
+                                .resizable()
+                                .aspectRatio(contentMode: .fit)
+                        case .failure:
+                            // Error state that maintains layout
+                            Rectangle()
+                                .fill(Color.gray.opacity(0.3))
+                                .aspectRatio(16/9, contentMode: .fit)
+                        @unknown default:
+                            Rectangle()
+                                .fill(Color.clear)
+                                .aspectRatio(16/9, contentMode: .fit)
                         }
                     }
-                }
-            } else {
-                // No image available - maintain layout with placeholder
-                Rectangle()
-                    .fill(Color.gray.opacity(0.2))
-                    .aspectRatio(16/9, contentMode: .fit)
                     .onAppear {
                         if !hasReportedImpression {
                             reportImpression()
                         }
                     }
+                    .onTapGesture {
+                        if isClickable {
+                            reportClick()
+                            if let redirectUrl = ad.redirect?.url, let url = URL(string: redirectUrl) {
+                                #if os(iOS) || os(tvOS)
+                                UIApplication.shared.open(url)
+                                #elseif os(macOS)
+                                NSWorkspace.shared.open(url)
+                                #endif
+                            }
+                        }
+                    }
+                } else {
+                    Rectangle()
+                        .fill(Color.gray.opacity(0.2))
+                        .aspectRatio(16/9, contentMode: .fit)
+
+                }
+
+            } else {
+                // No image available - maintain layout with placeholder
+                Rectangle()
+                    .fill(Color.gray.opacity(0.2))
+                    .aspectRatio(16/9, contentMode: .fit)
             }
         }
     }

--- a/Sources/AdViews/SponsoredProductView.swift
+++ b/Sources/AdViews/SponsoredProductView.swift
@@ -35,30 +35,41 @@ public struct SponsoredProductView: View {
             // Product Image
             Group {
                 if let imageUrl = imageUrl, let url = URL(string: imageUrl) {
-                    AsyncImage(url: url) { phase in
-                        switch phase {
-                        case .empty:
-                            Rectangle()
-                                .fill(Color.gray.opacity(0.2))
-                                .aspectRatio(1, contentMode: .fit)
-                        case .success(let image):
-                            image
-                                .resizable()
-                                .aspectRatio(contentMode: .fit)
-                        case .failure:
-                            Rectangle()
-                                .fill(Color.gray.opacity(0.3))
-                                .aspectRatio(1, contentMode: .fit)
-                                .overlay(
-                                    Image(systemName: "photo")
-                                        .foregroundColor(.gray)
-                                )
-                        @unknown default:
-                            Rectangle()
-                                .fill(Color.gray.opacity(0.2))
-                                .aspectRatio(1, contentMode: .fit)
+                    if #available(iOS 15, *) {
+                        AsyncImage(url: url) { phase in
+                            switch phase {
+                            case .empty:
+                                Rectangle()
+                                    .fill(Color.gray.opacity(0.2))
+                                    .aspectRatio(1, contentMode: .fit)
+                            case .success(let image):
+                                image
+                                    .resizable()
+                                    .aspectRatio(contentMode: .fit)
+                            case .failure:
+                                Rectangle()
+                                    .fill(Color.gray.opacity(0.3))
+                                    .aspectRatio(1, contentMode: .fit)
+                                    .overlay(
+                                        Image(systemName: "photo")
+                                            .foregroundColor(.gray)
+                                    )
+                            @unknown default:
+                                Rectangle()
+                                    .fill(Color.gray.opacity(0.2))
+                                    .aspectRatio(1, contentMode: .fit)
+                            }
                         }
+                    } else {
+                        Rectangle()
+                            .fill(Color.gray.opacity(0.2))
+                            .aspectRatio(1, contentMode: .fit)
+                            .overlay(
+                                Image(systemName: "photo")
+                                    .foregroundColor(.gray)
+                            )
                     }
+
                 } else {
                     Rectangle()
                         .fill(Color.gray.opacity(0.2))

--- a/Sources/Gowit/Version.swift
+++ b/Sources/Gowit/Version.swift
@@ -1,3 +1,3 @@
 import Foundation
 
-let gowitVersion = "1.0.1"
+let gowitVersion = "1.0.2"


### PR DESCRIPTION


<!-- This is an auto-generated comment: release notes by coderabbit.ai -->

## Summary by CodeRabbit

- Bug Fixes
  - Reliable image placeholders when no image or load fails, preserving a consistent 16:9 layout.
  - Graceful fallback on iOS versions prior to 15 (no AsyncImage), avoiding blank ad slots.
- Documentation
  - Updated README to reflect iOS 14.0+ support and dependency version 1.0.2.
- Chores
  - Lowered minimum iOS version to 14.0; package now targets iOS only.
  - Bumped package version to 1.0.2.

<!-- end of auto-generated comment: release notes by coderabbit.ai -->