### PR TITLE
feat: build-and-test CI, a typed capability manifest, and declarative standard-ad rendering

### DIFF
--- a/.github/workflows/build-test.yml
+++ b/.github/workflows/build-test.yml
@@ -1,0 +1,77 @@
+name: Build and Test
+
+# The linter runs on Linux and never compiles anything, so until this workflow
+# existed the package's test files were not built by CI at all - and one of them did
+# not compile. An iOS build needs a macOS runner with Xcode, so this job is the one
+# place in this repository that runs on a GitHub-hosted macOS image.
+on:
+  push:
+  pull_request:
+  workflow_dispatch:
+
+concurrency:
+  group: build-test-${{ github.ref }}
+  cancel-in-progress: true
+
+jobs:
+  build-and-test:
+    name: Build and test on the iOS simulator
+    runs-on: macos-latest
+    timeout-minutes: 30
+
+    steps:
+      - uses: actions/checkout@v4
+
+      - name: Toolchain
+        run: |
+          xcodebuild -version
+          swift --version
+
+      # The destination is resolved rather than hard-coded: the runner image's Xcode
+      # and its installed simulators both move, and a pinned device name turns a
+      # routine image update into a red build with a misleading reason. "iPhone"
+      # appears only under an iOS runtime, so the first match is an iOS simulator.
+      - name: Resolve a simulator destination
+        id: sim
+        run: |
+          set -euo pipefail
+          line=$(xcrun simctl list devices available | grep -m1 "iPhone" || true)
+          if [ -z "$line" ]; then
+            echo "No available iPhone simulator on this runner." >&2
+            xcrun simctl list devices available >&2
+            exit 1
+          fi
+          udid=$(printf '%s\n' "$line" | sed -E 's/.*\(([0-9A-Fa-f-]{36})\).*/\1/')
+          echo "Using:$line"
+          echo "udid=$udid" >> "$GITHUB_OUTPUT"
+
+      - name: Build the package
+        run: |
+          set -o pipefail
+          xcodebuild build \
+            -scheme Gowit-Package \
+            -destination "platform=iOS Simulator,id=${{ steps.sim.outputs.udid }}" \
+            -derivedDataPath .ci-build \
+            | tail -20
+
+      - name: Run the tests
+        run: |
+          set -o pipefail
+          xcodebuild test \
+            -scheme Gowit-Package \
+            -destination "platform=iOS Simulator,id=${{ steps.sim.outputs.udid }}" \
+            -derivedDataPath .ci-build \
+            | grep -E "Test Suite |Executed [0-9]+ tests|error:|\*\* TEST"
+
+      # The package compiling is not proof that a host application can consume it:
+      # the sample app is what exercises the product boundary and the renderer's
+      # lifecycle inside a real app process.
+      - name: Build the sample host application
+        run: |
+          set -o pipefail
+          xcodebuild build \
+            -project Examples/GowitSampleApp/GowitSampleApp.xcodeproj \
+            -scheme GowitSampleApp \
+            -destination "platform=iOS Simulator,id=${{ steps.sim.outputs.udid }}" \
+            -derivedDataPath .ci-build-sample \
+            | tail -20

--- a/Examples/GowitSampleApp/GowitSampleApp.xcodeproj/project.pbxproj
+++ b/Examples/GowitSampleApp/GowitSampleApp.xcodeproj/project.pbxproj
@@ -1,0 +1,274 @@
+// !$*UTF8*$!
+{
+	archiveVersion = 1;
+	classes = {
+	};
+	objectVersion = 77;
+	objects = {
+
+/* Begin PBXBuildFile section */
+		A1000000000000000000A1 /* Gowit in Frameworks */ = {isa = PBXBuildFile; productRef = A1000000000000000000B1 /* Gowit */; };
+		A1000000000000000000A2 /* AdViews in Frameworks */ = {isa = PBXBuildFile; productRef = A1000000000000000000B2 /* AdViews */; };
+/* End PBXBuildFile section */
+
+/* Begin PBXFileReference section */
+		A1000000000000000000C1 /* GowitSampleApp.app */ = {isa = PBXFileReference; explicitFileType = wrapper.application; includeInIndex = 0; path = GowitSampleApp.app; sourceTree = BUILT_PRODUCTS_DIR; };
+/* End PBXFileReference section */
+
+/* Begin PBXFileSystemSynchronizedRootGroup section */
+		A1000000000000000000D1 /* GowitSampleApp */ = {isa = PBXFileSystemSynchronizedRootGroup; explicitFileTypes = {}; explicitFolders = (); path = GowitSampleApp; sourceTree = "<group>"; };
+/* End PBXFileSystemSynchronizedRootGroup section */
+
+/* Begin PBXFrameworksBuildPhase section */
+		A1000000000000000000E1 /* Frameworks */ = {
+			isa = PBXFrameworksBuildPhase;
+			buildActionMask = 2147483647;
+			files = (
+				A1000000000000000000A1 /* Gowit in Frameworks */,
+				A1000000000000000000A2 /* AdViews in Frameworks */,
+			);
+			runOnlyForDeploymentPostprocessing = 0;
+		};
+/* End PBXFrameworksBuildPhase section */
+
+/* Begin PBXGroup section */
+		A1000000000000000000F1 = {
+			isa = PBXGroup;
+			children = (
+				A1000000000000000000D1 /* GowitSampleApp */,
+				A1000000000000000000F2 /* Products */,
+			);
+			sourceTree = "<group>";
+		};
+		A1000000000000000000F2 /* Products */ = {
+			isa = PBXGroup;
+			children = (
+				A1000000000000000000C1 /* GowitSampleApp.app */,
+			);
+			name = Products;
+			sourceTree = "<group>";
+		};
+/* End PBXGroup section */
+
+/* Begin PBXNativeTarget section */
+		A100000000000000000101 /* GowitSampleApp */ = {
+			isa = PBXNativeTarget;
+			buildConfigurationList = A100000000000000000111 /* Build configuration list for PBXNativeTarget "GowitSampleApp" */;
+			buildPhases = (
+				A100000000000000000121 /* Sources */,
+				A1000000000000000000E1 /* Frameworks */,
+				A100000000000000000131 /* Resources */,
+			);
+			buildRules = (
+			);
+			dependencies = (
+			);
+			fileSystemSynchronizedGroups = (
+				A1000000000000000000D1 /* GowitSampleApp */,
+			);
+			name = GowitSampleApp;
+			packageProductDependencies = (
+				A1000000000000000000B1 /* Gowit */,
+				A1000000000000000000B2 /* AdViews */,
+			);
+			productName = GowitSampleApp;
+			productReference = A1000000000000000000C1 /* GowitSampleApp.app */;
+			productType = "com.apple.product-type.application";
+		};
+/* End PBXNativeTarget section */
+
+/* Begin PBXProject section */
+		A100000000000000000141 /* Project object */ = {
+			isa = PBXProject;
+			attributes = {
+				BuildIndependentTargetsInParallel = 1;
+				LastSwiftUpdateCheck = 1600;
+				LastUpgradeCheck = 1600;
+				TargetAttributes = {
+					A100000000000000000101 = {
+						CreatedOnToolsVersion = 16.0;
+					};
+				};
+			};
+			buildConfigurationList = A100000000000000000151 /* Build configuration list for PBXProject "GowitSampleApp" */;
+			developmentRegion = en;
+			hasScannedForEncodings = 0;
+			knownRegions = (
+				en,
+				Base,
+			);
+			mainGroup = A1000000000000000000F1;
+			minimizedProjectReferenceProxies = 1;
+			packageReferences = (
+				A100000000000000000161 /* XCLocalSwiftPackageReference "../.." */,
+			);
+			preferredProjectObjectVersion = 77;
+			productRefGroup = A1000000000000000000F2 /* Products */;
+			projectDirPath = "";
+			projectRoot = "";
+			targets = (
+				A100000000000000000101 /* GowitSampleApp */,
+			);
+		};
+/* End PBXProject section */
+
+/* Begin PBXResourcesBuildPhase section */
+		A100000000000000000131 /* Resources */ = {
+			isa = PBXResourcesBuildPhase;
+			buildActionMask = 2147483647;
+			files = (
+			);
+			runOnlyForDeploymentPostprocessing = 0;
+		};
+/* End PBXResourcesBuildPhase section */
+
+/* Begin PBXSourcesBuildPhase section */
+		A100000000000000000121 /* Sources */ = {
+			isa = PBXSourcesBuildPhase;
+			buildActionMask = 2147483647;
+			files = (
+			);
+			runOnlyForDeploymentPostprocessing = 0;
+		};
+/* End PBXSourcesBuildPhase section */
+
+/* Begin XCBuildConfiguration section */
+		A100000000000000000171 /* Debug */ = {
+			isa = XCBuildConfiguration;
+			buildSettings = {
+				ALWAYS_SEARCH_USER_PATHS = NO;
+				CLANG_ENABLE_MODULES = YES;
+				CLANG_ENABLE_OBJC_ARC = YES;
+				COPY_PHASE_STRIP = NO;
+				DEBUG_INFORMATION_FORMAT = dwarf;
+				ENABLE_STRICT_OBJC_MSGSEND = YES;
+				ENABLE_TESTABILITY = YES;
+				GCC_NO_COMMON_BLOCKS = YES;
+				GCC_OPTIMIZATION_LEVEL = 0;
+				GCC_PREPROCESSOR_DEFINITIONS = (
+					"DEBUG=1",
+					"$(inherited)",
+				);
+				IPHONEOS_DEPLOYMENT_TARGET = 15.0;
+				MTL_ENABLE_DEBUG_INFO = INCLUDE_SOURCE;
+				MTL_FAST_MATH = YES;
+				ONLY_ACTIVE_ARCH = YES;
+				SDKROOT = iphoneos;
+				SWIFT_ACTIVE_COMPILATION_CONDITIONS = "DEBUG $(inherited)";
+				SWIFT_OPTIMIZATION_LEVEL = "-Onone";
+			};
+			name = Debug;
+		};
+		A100000000000000000172 /* Release */ = {
+			isa = XCBuildConfiguration;
+			buildSettings = {
+				ALWAYS_SEARCH_USER_PATHS = NO;
+				CLANG_ENABLE_MODULES = YES;
+				CLANG_ENABLE_OBJC_ARC = YES;
+				COPY_PHASE_STRIP = NO;
+				DEBUG_INFORMATION_FORMAT = "dwarf-with-dsym";
+				ENABLE_NS_ASSERTIONS = NO;
+				ENABLE_STRICT_OBJC_MSGSEND = YES;
+				GCC_NO_COMMON_BLOCKS = YES;
+				IPHONEOS_DEPLOYMENT_TARGET = 15.0;
+				MTL_ENABLE_DEBUG_INFO = NO;
+				MTL_FAST_MATH = YES;
+				SDKROOT = iphoneos;
+				SWIFT_COMPILATION_MODE = wholemodule;
+				VALIDATE_PRODUCT = YES;
+			};
+			name = Release;
+		};
+		A100000000000000000181 /* Debug */ = {
+			isa = XCBuildConfiguration;
+			buildSettings = {
+				ASSETCATALOG_COMPILER_GENERATE_ASSET_SYMBOL_FRAMEWORKS = SwiftUI;
+				CODE_SIGNING_ALLOWED = NO;
+				CODE_SIGNING_REQUIRED = NO;
+				CODE_SIGN_IDENTITY = "";
+				CODE_SIGN_STYLE = Automatic;
+				CURRENT_PROJECT_VERSION = 1;
+				ENABLE_USER_SCRIPT_SANDBOXING = YES;
+				GENERATE_INFOPLIST_FILE = YES;
+				INFOPLIST_KEY_UIApplicationSceneManifest_Generation = YES;
+				INFOPLIST_KEY_UIApplicationSupportsIndirectInputEvents = YES;
+				INFOPLIST_KEY_UILaunchScreen_Generation = YES;
+				INFOPLIST_KEY_UISupportedInterfaceOrientations = "UIInterfaceOrientationPortrait UIInterfaceOrientationLandscapeLeft UIInterfaceOrientationLandscapeRight";
+				IPHONEOS_DEPLOYMENT_TARGET = 15.0;
+				MARKETING_VERSION = 1.0;
+				PRODUCT_BUNDLE_IDENTIFIER = com.gowit.sample.GowitSampleApp;
+				PRODUCT_NAME = "$(TARGET_NAME)";
+				SWIFT_EMIT_LOC_STRINGS = YES;
+				SWIFT_VERSION = 5.0;
+				TARGETED_DEVICE_FAMILY = "1,2";
+			};
+			name = Debug;
+		};
+		A100000000000000000182 /* Release */ = {
+			isa = XCBuildConfiguration;
+			buildSettings = {
+				ASSETCATALOG_COMPILER_GENERATE_ASSET_SYMBOL_FRAMEWORKS = SwiftUI;
+				CODE_SIGNING_ALLOWED = NO;
+				CODE_SIGNING_REQUIRED = NO;
+				CODE_SIGN_IDENTITY = "";
+				CODE_SIGN_STYLE = Automatic;
+				CURRENT_PROJECT_VERSION = 1;
+				ENABLE_USER_SCRIPT_SANDBOXING = YES;
+				GENERATE_INFOPLIST_FILE = YES;
+				INFOPLIST_KEY_UIApplicationSceneManifest_Generation = YES;
+				INFOPLIST_KEY_UIApplicationSupportsIndirectInputEvents = YES;
+				INFOPLIST_KEY_UILaunchScreen_Generation = YES;
+				INFOPLIST_KEY_UISupportedInterfaceOrientations = "UIInterfaceOrientationPortrait UIInterfaceOrientationLandscapeLeft UIInterfaceOrientationLandscapeRight";
+				IPHONEOS_DEPLOYMENT_TARGET = 15.0;
+				MARKETING_VERSION = 1.0;
+				PRODUCT_BUNDLE_IDENTIFIER = com.gowit.sample.GowitSampleApp;
+				PRODUCT_NAME = "$(TARGET_NAME)";
+				SWIFT_EMIT_LOC_STRINGS = YES;
+				SWIFT_VERSION = 5.0;
+				TARGETED_DEVICE_FAMILY = "1,2";
+			};
+			name = Release;
+		};
+/* End XCBuildConfiguration section */
+
+/* Begin XCConfigurationList section */
+		A100000000000000000151 /* Build configuration list for PBXProject "GowitSampleApp" */ = {
+			isa = XCConfigurationList;
+			buildConfigurations = (
+				A100000000000000000171 /* Debug */,
+				A100000000000000000172 /* Release */,
+			);
+			defaultConfigurationIsVisible = 0;
+			defaultConfigurationName = Release;
+		};
+		A100000000000000000111 /* Build configuration list for PBXNativeTarget "GowitSampleApp" */ = {
+			isa = XCConfigurationList;
+			buildConfigurations = (
+				A100000000000000000181 /* Debug */,
+				A100000000000000000182 /* Release */,
+			);
+			defaultConfigurationIsVisible = 0;
+			defaultConfigurationName = Release;
+		};
+/* End XCConfigurationList section */
+
+/* Begin XCLocalSwiftPackageReference section */
+		A100000000000000000161 /* XCLocalSwiftPackageReference "../.." */ = {
+			isa = XCLocalSwiftPackageReference;
+			relativePath = ../..;
+		};
+/* End XCLocalSwiftPackageReference section */
+
+/* Begin XCSwiftPackageProductDependency section */
+		A1000000000000000000B1 /* Gowit */ = {
+			isa = XCSwiftPackageProductDependency;
+			productName = Gowit;
+		};
+		A1000000000000000000B2 /* AdViews */ = {
+			isa = XCSwiftPackageProductDependency;
+			productName = AdViews;
+		};
+/* End XCSwiftPackageProductDependency section */
+	};
+	rootObject = A100000000000000000141 /* Project object */;
+}

--- a/Examples/GowitSampleApp/GowitSampleApp.xcodeproj/xcshareddata/xcschemes/GowitSampleApp.xcscheme
+++ b/Examples/GowitSampleApp/GowitSampleApp.xcodeproj/xcshareddata/xcschemes/GowitSampleApp.xcscheme
@@ -1,0 +1,44 @@
+<?xml version="1.0" encoding="UTF-8"?>
+<Scheme LastUpgradeVersion = "1600" version = "1.7">
+   <BuildAction parallelizeBuildables = "YES" buildImplicitDependencies = "YES">
+      <BuildActionEntries>
+         <BuildActionEntry buildForTesting = "YES" buildForRunning = "YES" buildForProfiling = "YES" buildForArchiving = "YES" buildForAnalyzing = "YES">
+            <BuildableReference
+               BuildableIdentifier = "primary"
+               BlueprintIdentifier = "A100000000000000000101"
+               BuildableName = "GowitSampleApp.app"
+               BlueprintName = "GowitSampleApp"
+               ReferencedContainer = "container:GowitSampleApp.xcodeproj">
+            </BuildableReference>
+         </BuildActionEntry>
+      </BuildActionEntries>
+   </BuildAction>
+   <TestAction buildConfiguration = "Debug" selectedDebuggerIdentifier = "Xcode.DebuggerFoundation.Debugger.LLDB" selectedLauncherIdentifier = "Xcode.DebuggerFoundation.Launcher.LLDB" shouldUseLaunchSchemeArgsEnv = "YES">
+      <Testables>
+      </Testables>
+   </TestAction>
+   <LaunchAction buildConfiguration = "Debug" selectedDebuggerIdentifier = "Xcode.DebuggerFoundation.Debugger.LLDB" selectedLauncherIdentifier = "Xcode.DebuggerFoundation.Launcher.LLDB" launchStyle = "0" useCustomWorkingDirectory = "NO" ignoresPersistentStateOnLaunch = "NO" debugDocumentVersioning = "YES" debugServiceExtension = "internal" allowLocationSimulation = "YES">
+      <BuildableProductRunnable runnableDebuggingMode = "0">
+         <BuildableReference
+            BuildableIdentifier = "primary"
+            BlueprintIdentifier = "A100000000000000000101"
+            BuildableName = "GowitSampleApp.app"
+            BlueprintName = "GowitSampleApp"
+            ReferencedContainer = "container:GowitSampleApp.xcodeproj">
+         </BuildableReference>
+      </BuildableProductRunnable>
+   </LaunchAction>
+   <ProfileAction buildConfiguration = "Release" shouldUseLaunchSchemeArgsEnv = "YES" savedToolIdentifier = "" useCustomWorkingDirectory = "NO" debugDocumentVersioning = "YES">
+      <BuildableProductRunnable runnableDebuggingMode = "0">
+         <BuildableReference
+            BuildableIdentifier = "primary"
+            BlueprintIdentifier = "A100000000000000000101"
+            BuildableName = "GowitSampleApp.app"
+            BlueprintName = "GowitSampleApp"
+            ReferencedContainer = "container:GowitSampleApp.xcodeproj">
+         </BuildableReference>
+      </BuildableProductRunnable>
+   </ProfileAction>
+   <AnalyzeAction buildConfiguration = "Debug"></AnalyzeAction>
+   <ArchiveAction buildConfiguration = "Release" revealArchiveInOrganizer = "YES"></ArchiveAction>
+</Scheme>

--- a/Examples/GowitSampleApp/GowitSampleApp/ContentView.swift
+++ b/Examples/GowitSampleApp/GowitSampleApp/ContentView.swift
@@ -1,0 +1,154 @@
+import SwiftUI
+import Gowit
+import AdViews
+
+/// The one fixture this sample renders, and the errors it can fail to load with.
+enum FixtureLoader {
+    enum Failure: Error, LocalizedError {
+        case notBundled
+        case undecodable(Error)
+        case noAd
+
+        var errorDescription: String? {
+            switch self {
+            case .notBundled: return "standard-ad-response.json is not in the app bundle."
+            case .undecodable(let error): return "The fixture did not decode: \(error)"
+            case .noAd: return "The fixture decoded but carries no ad."
+            }
+        }
+    }
+
+    /// Load the first ad of the first placement. A missing fixture is surfaced, never
+    /// swallowed into an empty screen that looks like a no-fill.
+    static func loadFirstAd() -> Result<Ad, Failure> {
+        guard let url = Bundle.main.url(forResource: "standard-ad-response", withExtension: "json"),
+              let data = try? Data(contentsOf: url) else {
+            return .failure(.notBundled)
+        }
+        do {
+            let response = try JSONDecoder().decode(AdResponse.self, from: data)
+            guard let ad = response.allAds.first else { return .failure(.noAd) }
+            return .success(ad)
+        } catch {
+            return .failure(.undecodable(error))
+        }
+    }
+}
+
+struct ContentView: View {
+    @StateObject private var log = RenderLog()
+    @State private var loaded = FixtureLoader.loadFirstAd()
+    @State private var lastAction: String?
+
+    var body: some View {
+        NavigationView {
+            ScrollView {
+                VStack(alignment: .leading, spacing: 20) {
+                    manifestSection
+
+                    section("Rendered ad") {
+                        switch loaded {
+                        case .success(let ad):
+                            StandardAdContainerView(
+                                ad: ad,
+                                capability: GowitCapabilities.installed(in: geometry),
+                                lifecycle: log.lifecycle,
+                                onAction: { request in
+                                    // The host decides what an action means. The renderer
+                                    // hands over a token and a URL and never reaches into
+                                    // the app itself.
+                                    lastAction = "\(request.token) -> \(request.url.absoluteString)"
+                                    log.append("action \(request.token)")
+                                }
+                            )
+                            .accessibilityIdentifier("gowit.standard-ad")
+                        case .failure(let error):
+                            Text(error.localizedDescription)
+                                .font(.footnote)
+                                .foregroundColor(.red)
+                                .accessibilityIdentifier("gowit.fixture-error")
+                        }
+                    }
+
+                    if let lastAction = lastAction {
+                        section("Last action") {
+                            Text(lastAction).font(.caption).textSelection(.enabled)
+                        }
+                    }
+
+                    section("Lifecycle") {
+                        VStack(alignment: .leading, spacing: 4) {
+                            ForEach(Array(log.lines.enumerated()), id: \.offset) { item in
+                                Text(item.element).font(.system(.caption, design: .monospaced))
+                            }
+                        }
+                        .accessibilityIdentifier("gowit.lifecycle-log")
+                    }
+                }
+                .padding()
+            }
+            .navigationTitle("Gowit sample host")
+        }
+        .navigationViewStyle(.stack)
+    }
+
+    /// The space actually available at request time, which is a property of the
+    /// request rather than of the installed build.
+    private var geometry: GeometryCapability {
+        GeometryCapability(
+            availableWidth: Int(UIScreen.main.bounds.width),
+            availableHeight: 240,
+            density: Double(UIScreen.main.scale),
+            heightMayChange: true
+        )
+    }
+
+    private var manifestSection: some View {
+        section("Declared capabilities") {
+            VStack(alignment: .leading, spacing: 4) {
+                row("platform", GowitCapabilities.installed.platform.rawValue)
+                row("renderer_version", GowitCapabilities.rendererVersion)
+                row("protocol_major", String(GowitCapabilities.protocolMajor))
+                row("minimum_os", "\(GowitCapabilities.support.minimumOS) (\(GowitCapabilities.support.status.rawValue))")
+                row("primitives", (GowitCapabilities.installed.primitives ?? []).count.description)
+                row("observation", (GowitCapabilities.installed.observation ?? []).joined(separator: ", "))
+            }
+            .accessibilityIdentifier("gowit.manifest")
+        }
+    }
+
+    private func row(_ key: String, _ value: String) -> some View {
+        HStack(alignment: .top) {
+            Text(key).font(.system(.caption, design: .monospaced)).foregroundColor(.secondary)
+            Spacer(minLength: 12)
+            Text(value).font(.system(.caption, design: .monospaced)).multilineTextAlignment(.trailing)
+        }
+    }
+
+    private func section<Content: View>(_ title: String, @ViewBuilder content: () -> Content) -> some View {
+        VStack(alignment: .leading, spacing: 8) {
+            Text(title).font(.headline)
+            content()
+        }
+    }
+}
+
+/// Collects the renderer's lifecycle events so the simulator run has something to
+/// show, and echoes them to stdout so a headless launch is evidence too.
+final class RenderLog: ObservableObject {
+    @Published private(set) var lines: [String] = []
+    private(set) lazy var lifecycle = AdRenderLifecycle { [weak self] event in
+        switch event {
+        case .mounted(let adID): self?.append("mounted \(adID ?? "-")")
+        case .exposed(let adID): self?.append("exposed \(adID ?? "-")")
+        case .disposed(let adID): self?.append("disposed \(adID ?? "-")")
+        case .refused(let refusal):
+            self?.append("refused \(refusal.code.rawValue) \((refusal.missingCapabilities ?? []).joined(separator: ","))")
+        }
+    }
+
+    func append(_ line: String) {
+        print("[gowit-sample] \(line)")
+        DispatchQueue.main.async { self.lines.append(line) }
+    }
+}

--- a/Examples/GowitSampleApp/GowitSampleApp/Fixtures/standard-ad-response.json
+++ b/Examples/GowitSampleApp/GowitSampleApp/Fixtures/standard-ad-response.json
@@ -1,0 +1,34 @@
+{
+  "response_id": "fixture-response-0001",
+  "placements": [
+    {
+      "placement_id": 101,
+      "placement_identifier": "home_top",
+      "ads": [
+        {
+          "ad_id": "fixture-ad-0001",
+          "creative_id": 4242,
+          "advertiser_id": "fixture-advertiser-0001",
+          "img_url": "https://example.invalid/creative.png",
+          "size": "320x100",
+          "position": 1,
+          "redirect": {
+            "url": "https://example.invalid/product/SKU-77",
+            "type": "product"
+          },
+          "products": [
+            {
+              "name": "Stainless Steel Kettle 1.7L",
+              "sku": "SKU-77",
+              "image_url": "https://example.invalid/product/SKU-77.png",
+              "rating": 4.6,
+              "price": 749.9,
+              "stock_count": 12,
+              "advertiser_id": "fixture-advertiser-0001"
+            }
+          ]
+        }
+      ]
+    }
+  ]
+}

--- a/Examples/GowitSampleApp/GowitSampleApp/GowitSampleApp.swift
+++ b/Examples/GowitSampleApp/GowitSampleApp/GowitSampleApp.swift
@@ -1,0 +1,16 @@
+import SwiftUI
+
+/// A minimal host for the declarative standard-ad renderer.
+///
+/// It exists to prove the lifecycle in a simulator, so it deliberately makes **no
+/// network call**: the ad it draws is decoded from a bundled fixture. A sample that
+/// needed a reachable ad server would prove the server was up, not that the renderer
+/// works.
+@main
+struct GowitSampleApp: App {
+    var body: some Scene {
+        WindowGroup {
+            ContentView()
+        }
+    }
+}

--- a/Package.swift
+++ b/Package.swift
@@ -34,7 +34,7 @@ let package = Package(
         ),
         .testTarget(
             name: "gowit.swiftTests",
-            dependencies: ["Gowit"]
+            dependencies: ["Gowit", "AdViews"]
         )
     ]
 )

--- a/Sources/AdViews/Declarative/StandardAdPlan.swift
+++ b/Sources/AdViews/Declarative/StandardAdPlan.swift
@@ -1,0 +1,231 @@
+import Foundation
+import Gowit
+
+/// The semantic role a node fills, bound to a native view by the renderer rather
+/// than to a pixel position by the server. Roles are what let one profile produce an
+/// appropriate layout on each platform instead of one platform's layout everywhere.
+public enum AdSlotRole: String, Codable, CaseIterable {
+    case root
+    case media
+    case headline
+    case price
+    case rating
+    case sponsorshipLabel = "sponsorship_label"
+    case callToAction = "call_to_action"
+}
+
+/// The bounded declarative grammar for a standard ad.
+///
+/// It is bounded on purpose: a node kind that is not in this enum cannot be sent,
+/// and a new kind requires a client release. That is the whole difference between
+/// declaring capabilities and downloading executable code — which this renderer
+/// never does.
+public indirect enum StandardAdNode: Equatable {
+    /// `primitive.container`
+    case container(role: AdSlotRole, children: [StandardAdNode])
+    /// `primitive.image`
+    case image(role: AdSlotRole, url: URL, accessibilityLabel: String?)
+    /// `primitive.text`
+    case text(role: AdSlotRole, value: String)
+    /// `primitive.entity_card` — one promoted entity drawn as a unit.
+    case entityCard(role: AdSlotRole, children: [StandardAdNode])
+
+    /// The capability token this node needs in order to be drawn.
+    public var requiredCapability: String {
+        switch self {
+        case .container: return CapabilityToken.Primitive.container
+        case .image: return CapabilityToken.Primitive.image
+        case .text: return CapabilityToken.Primitive.text
+        case .entityCard: return CapabilityToken.Primitive.entityCard
+        }
+    }
+
+    /// Every token this node and its descendants need, deduplicated, in first-seen order.
+    public var requiredCapabilities: [String] {
+        var seen: [String] = []
+        func walk(_ node: StandardAdNode) {
+            if !seen.contains(node.requiredCapability) { seen.append(node.requiredCapability) }
+            switch node {
+            case .container(_, let children), .entityCard(_, let children):
+                children.forEach(walk)
+            case .image, .text:
+                break
+            }
+        }
+        walk(self)
+        return seen
+    }
+}
+
+/// What the host may be asked to do when the ad is tapped.
+///
+/// The payload is a URL and nothing else. There is no field that could name a host
+/// selector, a method or a script, so an action can never invoke arbitrary host
+/// functionality however it is spelled on the wire.
+public struct AdActionRequest: Equatable {
+    public let token: String
+    public let url: URL
+
+    public init(token: String, url: URL) {
+        self.token = token
+        self.url = url
+    }
+}
+
+/// A resolved, executable render plan: a tree that this runtime has already been
+/// proven able to draw, plus the identity the measurement of it is reported under.
+public struct StandardAdPlan: Equatable {
+    public let adId: String?
+    public let root: StandardAdNode
+    public let action: AdActionRequest?
+
+    public init(adId: String?, root: StandardAdNode, action: AdActionRequest?) {
+        self.adId = adId
+        self.root = root
+        self.action = action
+    }
+
+    /// Every capability the plan needs, including the action's.
+    public var requiredCapabilities: [String] {
+        var required = root.requiredCapabilities
+        if let action = action, !required.contains(action.token) {
+            required.append(action.token)
+        }
+        return required
+    }
+}
+
+// MARK: - Resolution
+
+public enum StandardAdResolver {
+
+    /// The token an opaque-markup ad requires. It is an ISOLATION capability, not a
+    /// primitive: drawing a frame and confining what runs inside it are different
+    /// claims, and only the second one makes advertiser markup safe to execute.
+    public static let sandboxToken = "isolation.sandboxed"
+
+    /// Turn one served ad into a plan this runtime can execute, or refuse with the
+    /// exact tokens that are missing.
+    ///
+    /// Three refusals, and each is deliberate:
+    ///
+    /// - **Opaque markup** is refused rather than drawn. A known absent capability is
+    ///   incompatibility; it is never degraded and never silently converted into an
+    ///   embedded browser view. This build declares `isolation.sandboxed = false`, so
+    ///   an ad whose content is advertiser markup cannot be rendered here even though
+    ///   `primitive.html_frame` is declared.
+    /// - **Video** is refused unless the vector declares both the primitive and a
+    ///   playback lifecycle, because parsing is not playing.
+    /// - **A missing primitive** is refused with every token the tree needed and the
+    ///   vector did not name, not just the first.
+    public static func resolve(
+        ad: Ad,
+        capability: RendererCapability
+    ) -> Result<StandardAdPlan, CapabilityRefusal> {
+
+        guard capability.protocolMajor == GowitCapabilities.protocolMajor else {
+            return .failure(.unsupportedProtocolMajor(capability.protocolMajor))
+        }
+
+        if let html = ad.html, !html.isEmpty {
+            if capability.isolation?.sandboxed != true {
+                return .failure(.missingCapability(
+                    [sandboxToken],
+                    message: "Opaque advertiser markup requires an isolated profile; this runtime declares a frame but not a sandbox."
+                ))
+            }
+            return .failure(.missingCapability(
+                [sandboxToken],
+                message: "Opaque markup is rendered by the isolated WebView profile, not by the declarative standard-ad renderer."
+            ))
+        }
+
+        if let video = ad.videoUrl, !video.isEmpty {
+            var missing: [String] = []
+            if capability.declares(CapabilityToken.Primitive.video) == false {
+                missing.append(CapabilityToken.Primitive.video)
+            }
+            if capability.media?.videoLifecycle != true {
+                missing.append("media.video_lifecycle")
+            }
+            if !missing.isEmpty {
+                return .failure(.missingCapability(missing, message: "Video content on a runtime without playback."))
+            }
+        }
+
+        guard let root = buildTree(ad: ad) else {
+            return .failure(CapabilityRefusal(
+                refusalClass: .incompatible,
+                code: .noCompatibleVariant,
+                message: "The ad carries neither media nor text this renderer can draw."
+            ))
+        }
+
+        let action = buildAction(ad: ad, capability: capability)
+
+        var required = root.requiredCapabilities
+        if let action = action { required.append(action.token) }
+        let missing = capability.missingCapabilities(from: required)
+        guard missing.isEmpty else {
+            return .failure(.missingCapability(missing))
+        }
+
+        return .success(StandardAdPlan(adId: ad.adId, root: root, action: action))
+    }
+
+    /// Prefer an in-app browser when the runtime declares one, and fall back to the
+    /// system URL open. An action is only ever chosen from tokens the vector NAMES —
+    /// resolution never invents one and never falls back to "do nothing", because a
+    /// click that quietly does nothing is indistinguishable from a broken ad.
+    private static func buildAction(ad: Ad, capability: RendererCapability) -> AdActionRequest? {
+        guard let raw = ad.clickUrl, let url = URL(string: raw) else { return nil }
+        if capability.declares(CapabilityToken.Action.inAppBrowser) {
+            return AdActionRequest(token: CapabilityToken.Action.inAppBrowser, url: url)
+        }
+        if capability.declares(CapabilityToken.Action.openURL) {
+            return AdActionRequest(token: CapabilityToken.Action.openURL, url: url)
+        }
+        return AdActionRequest(token: CapabilityToken.Action.openURL, url: url)
+    }
+
+    private static func buildTree(ad: Ad) -> StandardAdNode? {
+        if let product = ad.products?.first {
+            var children: [StandardAdNode] = []
+            if let raw = product.imageUrl ?? ad.imgUrl, let url = URL(string: raw) {
+                children.append(.image(role: .media, url: url, accessibilityLabel: product.name))
+            }
+            if let name = product.name, !name.isEmpty {
+                children.append(.text(role: .headline, value: name))
+            }
+            if let price = product.price {
+                children.append(.text(role: .price, value: formatPrice(price)))
+            }
+            if let rating = product.rating, rating > 0 {
+                children.append(.text(role: .rating, value: String(format: "%.1f", rating)))
+            }
+            children.append(.text(role: .sponsorshipLabel, value: sponsorshipLabel))
+            guard !children.isEmpty else { return nil }
+            return .entityCard(role: .root, children: children)
+        }
+
+        var children: [StandardAdNode] = []
+        if let raw = ad.imgUrl, !raw.isEmpty, let url = URL(string: raw) {
+            children.append(.image(role: .media, url: url, accessibilityLabel: nil))
+        }
+        children.append(.text(role: .sponsorshipLabel, value: sponsorshipLabel))
+        guard children.count > 1 else { return nil }
+        return .container(role: .root, children: children)
+    }
+
+    /// The disclosure every standard ad carries. It is part of the tree rather than a
+    /// decoration the host may forget, so a plan cannot be drawn without it.
+    public static let sponsorshipLabel = "Sponsored"
+
+    private static func formatPrice(_ value: Double) -> String {
+        let formatter = NumberFormatter()
+        formatter.numberStyle = .decimal
+        formatter.minimumFractionDigits = 2
+        formatter.maximumFractionDigits = 2
+        return formatter.string(from: NSNumber(value: value)) ?? String(format: "%.2f", value)
+    }
+}

--- a/Sources/AdViews/Declarative/StandardAdView.swift
+++ b/Sources/AdViews/Declarative/StandardAdView.swift
@@ -1,0 +1,248 @@
+import SwiftUI
+import Gowit
+
+/// The stages a rendered ad passes through, reported separately because request
+/// success, render readiness, exposure and error are four different facts and
+/// collapsing them is how an empty response comes to fire a success impression.
+public enum AdRenderEvent: Equatable {
+    case mounted(adId: String?)
+    case exposed(adId: String?)
+    case refused(CapabilityRefusal)
+    case disposed(adId: String?)
+}
+
+/// Owns one rendered ad's lifetime.
+///
+/// The impression is fired **once per mounted identity**. A recycled list cell hands
+/// the same view a different ad, so the guard is keyed on the ad's own id rather than
+/// on the view's existence — a view-scoped `hasFired` flag would suppress the second
+/// ad's impression entirely and count the first one twice on the way back.
+public final class AdRenderLifecycle: ObservableObject {
+    private var exposedAdID: String?
+    private let onEvent: ((AdRenderEvent) -> Void)?
+
+    public init(onEvent: ((AdRenderEvent) -> Void)? = nil) {
+        self.onEvent = onEvent
+    }
+
+    public func mount(adID: String?) {
+        onEvent?(.mounted(adId: adID))
+    }
+
+    /// Report exposure for `adID` unless this identity has already been reported.
+    /// Returns whether it fired, so a caller can assert the once-only rule.
+    @discardableResult
+    public func expose(adID: String?) -> Bool {
+        guard exposedAdID != adID else { return false }
+        exposedAdID = adID
+        onEvent?(.exposed(adId: adID))
+        return true
+    }
+
+    public func refuse(_ refusal: CapabilityRefusal) {
+        onEvent?(.refused(refusal))
+    }
+
+    /// Release the identity so a reused view starts clean, and tell the host the
+    /// surface is gone. Nothing here retains the view.
+    public func dispose() {
+        let adID = exposedAdID
+        exposedAdID = nil
+        onEvent?(.disposed(adId: adID))
+    }
+}
+
+/// Draws a resolved plan with native views.
+///
+/// It renders a plan, never an `Ad`: resolution has already refused anything this
+/// runtime cannot execute, so there is no branch here that could quietly substitute
+/// a browser view for a native one.
+public struct StandardAdView: View {
+    private let plan: StandardAdPlan
+    private let onAction: ((AdActionRequest) -> Void)?
+    @ObservedObject private var lifecycle: AdRenderLifecycle
+
+    public init(
+        plan: StandardAdPlan,
+        lifecycle: AdRenderLifecycle,
+        onAction: ((AdActionRequest) -> Void)? = nil
+    ) {
+        self.plan = plan
+        self.lifecycle = lifecycle
+        self.onAction = onAction
+    }
+
+    public var body: some View {
+        AdNodeView(node: plan.root)
+            .contentShape(Rectangle())
+            .modifier(TapAction(action: plan.action, onAction: onAction))
+            .accessibilityElement(children: .combine)
+            .accessibilityLabel(Text(accessibilitySummary))
+            .accessibilityAddTraits(plan.action == nil ? [] : .isButton)
+            .onAppear {
+                lifecycle.mount(adID: plan.adId)
+                lifecycle.expose(adID: plan.adId)
+            }
+            .onDisappear { lifecycle.dispose() }
+    }
+
+    /// One spoken sentence for the whole ad. The disclosure leads, because a screen
+    /// reader user learns it is an ad before they learn what it sells.
+    private var accessibilitySummary: String {
+        var parts: [String] = []
+        func walk(_ node: StandardAdNode) {
+            switch node {
+            case .text(let role, let value):
+                if role == .sponsorshipLabel { parts.insert(value, at: 0) } else { parts.append(value) }
+            case .image(_, _, let label):
+                if let label = label, !label.isEmpty { parts.append(label) }
+            case .container(_, let children), .entityCard(_, let children):
+                children.forEach(walk)
+            }
+        }
+        walk(plan.root)
+        return parts.joined(separator: ", ")
+    }
+
+}
+
+/// One node of the grammar, drawn.
+///
+/// It is a named type rather than a `@ViewBuilder` method on `StandardAdView` because
+/// the grammar is a tree and a method that returns `some View` while calling itself
+/// defines its own opaque type in terms of itself. A concrete struct recursing into
+/// itself is the shape SwiftUI can actually type-check.
+struct AdNodeView: View {
+    let node: StandardAdNode
+
+    var body: some View {
+        switch node {
+        case .container(_, let children):
+            VStack(alignment: .leading, spacing: 8) {
+                ForEach(Array(children.enumerated()), id: \.offset) { item in
+                    AdNodeView(node: item.element)
+                }
+            }
+
+        case .entityCard(_, let children):
+            VStack(alignment: .leading, spacing: 6) {
+                ForEach(Array(children.enumerated()), id: \.offset) { item in
+                    AdNodeView(node: item.element)
+                }
+            }
+            .padding(10)
+            .background(
+                RoundedRectangle(cornerRadius: 10)
+                    .fill(Color.secondary.opacity(0.08))
+            )
+
+        case .image(_, let url, _):
+            AsyncImage(url: url) { phase in
+                switch phase {
+                case .success(let image):
+                    image.resizable().aspectRatio(contentMode: .fit)
+                case .failure:
+                    AdNodePlaceholder(systemName: "photo")
+                case .empty:
+                    AdNodePlaceholder(systemName: nil)
+                @unknown default:
+                    AdNodePlaceholder(systemName: nil)
+                }
+            }
+            // A media region that grows to whatever the image reports would let one
+            // creative push the host's own content off the screen. The ceiling is the
+            // renderer's, not the creative's.
+            .frame(maxWidth: .infinity, maxHeight: Self.mediaHeightCeiling)
+            .accessibilityHidden(true)
+
+        case .text(let role, let value):
+            Text(value)
+                .font(Self.font(for: role))
+                .foregroundColor(role == .sponsorshipLabel ? .secondary : .primary)
+                .lineLimit(role == .headline ? 2 : 1)
+                .multilineTextAlignment(.leading)
+                .frame(maxWidth: .infinity, alignment: .leading)
+        }
+    }
+
+    /// The tallest a media region may draw, in points.
+    static let mediaHeightCeiling: CGFloat = 180
+
+    /// Text styles, never fixed point sizes, so the ad follows the reader's own
+    /// Dynamic Type setting instead of overriding it.
+    static func font(for role: AdSlotRole) -> Font {
+        switch role {
+        case .headline: return .subheadline.weight(.medium)
+        case .price: return .headline
+        case .rating, .sponsorshipLabel: return .caption
+        default: return .body
+        }
+    }
+}
+
+struct AdNodePlaceholder: View {
+    let systemName: String?
+
+    var body: some View {
+        Rectangle()
+            .fill(Color.secondary.opacity(0.15))
+            .aspectRatio(1, contentMode: .fit)
+            .overlay(
+                Group {
+                    if let systemName = systemName {
+                        Image(systemName: systemName).foregroundColor(.secondary)
+                    }
+                }
+            )
+    }
+}
+
+/// A tap gesture only where there is an action to run. An ad with no action must not
+/// look tappable, and a tap on it must not be swallowed from the host's own gestures.
+private struct TapAction: ViewModifier {
+    let action: AdActionRequest?
+    let onAction: ((AdActionRequest) -> Void)?
+
+    func body(content: Content) -> some View {
+        if let action = action, let onAction = onAction {
+            content.onTapGesture { onAction(action) }
+        } else {
+            content
+        }
+    }
+}
+
+/// Renders an ad, or renders nothing and reports why.
+///
+/// The refusal path draws an empty view rather than an error card: a refusal is an
+/// operator fact, and a placeholder in a retailer's app would turn a contract
+/// decision into a visible defect for a shopper.
+public struct StandardAdContainerView: View {
+    private let ad: Ad
+    private let capability: RendererCapability
+    private let lifecycle: AdRenderLifecycle
+    private let onAction: ((AdActionRequest) -> Void)?
+
+    public init(
+        ad: Ad,
+        capability: RendererCapability = GowitCapabilities.installed,
+        lifecycle: AdRenderLifecycle,
+        onAction: ((AdActionRequest) -> Void)? = nil
+    ) {
+        self.ad = ad
+        self.capability = capability
+        self.lifecycle = lifecycle
+        self.onAction = onAction
+    }
+
+    public var body: some View {
+        switch StandardAdResolver.resolve(ad: ad, capability: capability) {
+        case .success(let plan):
+            StandardAdView(plan: plan, lifecycle: lifecycle, onAction: onAction)
+        case .failure(let refusal):
+            Color.clear
+                .frame(width: 0, height: 0)
+                .onAppear { lifecycle.refuse(refusal) }
+        }
+    }
+}

--- a/Sources/Gowit/Capabilities/CapabilityRefusal.swift
+++ b/Sources/Gowit/Capabilities/CapabilityRefusal.swift
@@ -1,0 +1,73 @@
+import Foundation
+
+/// The class a refusal belongs to. A reader branches on `class` before it reads
+/// `code`, so that the same invalid tuple gets the same class in every language.
+public enum RefusalClass: String, Codable {
+    case unauthorized
+    case incompatible
+    case unsupported
+    case invalidContent = "invalid_content"
+    case conflict
+    /// An upstream outage. NOT `incompatible`: a known absent capability is
+    /// incompatibility, while an outage is not a statement about the ad.
+    case degraded
+}
+
+/// The subset of the platform's closed refusal vocabulary this client can raise
+/// locally. The server's vocabulary is wider; a client that meets a code it does not
+/// know reports it verbatim rather than reclassifying it.
+public enum RefusalCode: String, Codable {
+    case missingCapability = "MISSING_CAPABILITY"
+    case unsupportedProtocolMajor = "UNSUPPORTED_PROTOCOL_MAJOR"
+    case geometryIncompatible = "GEOMETRY_INCOMPATIBLE"
+    case noCompatibleVariant = "NO_COMPATIBLE_VARIANT"
+}
+
+/// A structured refusal. A refusal names WHAT was wrong; it never carries advertiser
+/// copy, media bytes or markup, which is why there is no field that could hold them.
+public struct CapabilityRefusal: Error, Codable, Equatable {
+    public let refusalClass: RefusalClass
+    public let code: RefusalCode
+    /// On `MISSING_CAPABILITY`: the tokens the variant required and this runtime did
+    /// not declare. Naming them is the difference between a refusal a caller can act
+    /// on and one it can only log.
+    public let missingCapabilities: [String]?
+    /// Optional operator-facing English. Never rendered to an advertiser, never parsed.
+    public let message: String?
+
+    public init(
+        refusalClass: RefusalClass,
+        code: RefusalCode,
+        missingCapabilities: [String]? = nil,
+        message: String? = nil
+    ) {
+        self.refusalClass = refusalClass
+        self.code = code
+        self.missingCapabilities = missingCapabilities
+        self.message = message
+    }
+
+    enum CodingKeys: String, CodingKey {
+        case refusalClass = "class"
+        case code
+        case missingCapabilities = "missing_capabilities"
+        case message
+    }
+
+    public static func missingCapability(_ tokens: [String], message: String? = nil) -> CapabilityRefusal {
+        CapabilityRefusal(refusalClass: .incompatible, code: .missingCapability, missingCapabilities: tokens, message: message)
+    }
+
+    public static func unsupportedProtocolMajor(_ major: Int) -> CapabilityRefusal {
+        CapabilityRefusal(refusalClass: .incompatible, code: .unsupportedProtocolMajor, message: "protocol_major \(major)")
+    }
+}
+
+extension CapabilityRefusal: LocalizedError {
+    public var errorDescription: String? {
+        if let tokens = missingCapabilities, !tokens.isEmpty {
+            return "\(code.rawValue): \(tokens.joined(separator: ", "))"
+        }
+        return code.rawValue
+    }
+}

--- a/Sources/Gowit/Capabilities/CapabilityToken.swift
+++ b/Sources/Gowit/Capabilities/CapabilityToken.swift
@@ -1,0 +1,49 @@
+import Foundation
+
+/// The namespaced capability tokens this client understands.
+///
+/// The token set is deliberately **open**. A reader must ignore a token it does not
+/// know rather than refuse the vector that carries it, so these constants are the
+/// tokens this build can justify — not a closed universe.
+///
+/// New primitives, privileged actions and unsupported codecs require a client
+/// release; changing a supported recipe does not. That asymmetry is the reason the
+/// client declares capabilities rather than a version.
+public enum CapabilityToken {
+
+    /// What the runtime can DRAW. Namespace `primitive.*`.
+    public enum Primitive {
+        public static let image = "primitive.image"
+        public static let text = "primitive.text"
+        public static let container = "primitive.container"
+        public static let entityCard = "primitive.entity_card"
+        public static let video = "primitive.video"
+        public static let htmlFrame = "primitive.html_frame"
+    }
+
+    /// What the runtime can DO on a click. Namespace `action.*`.
+    ///
+    /// An action the runtime does not declare makes the variant incompatible; it does
+    /// **not** make the click a no-op, and an unknown action name may never invoke
+    /// arbitrary host functionality.
+    public enum Action {
+        public static let openURL = "action.open_url"
+        public static let entityDestination = "action.entity_destination"
+        public static let inAppBrowser = "action.in_app_browser"
+        public static let hostCallback = "action.host_callback"
+    }
+
+    /// What the runtime can MEASURE and report. Namespace `observation.*`.
+    ///
+    /// A renderer without completion measurement cannot advertise completion
+    /// coverage: omitting `videoCompletion` here is what refuses a variant whose
+    /// profile requires it.
+    public enum Observation {
+        public static let rootImpression = "observation.root_impression"
+        public static let viewability = "observation.viewability"
+        public static let click = "observation.click"
+        public static let entityExposure = "observation.entity_exposure"
+        public static let videoCompletion = "observation.video_completion"
+        public static let foregroundState = "observation.foreground_state"
+    }
+}

--- a/Sources/Gowit/Capabilities/GowitCapabilities.swift
+++ b/Sources/Gowit/Capabilities/GowitCapabilities.swift
@@ -1,0 +1,125 @@
+import Foundation
+
+/// How firm a support statement is.
+///
+/// The operating-system floor is a **release-time** decision, deferred with a
+/// provisional default until the installed distribution is measured. Publishing it
+/// as `provisional` is what keeps a build target from being read as a support
+/// commitment nobody made.
+public enum SupportStatus: String, Codable {
+    case provisional
+    case committed
+}
+
+/// What this build says about the operating systems it runs on.
+///
+/// `minimumOS` is the package's compiled deployment target — a fact. `status` is
+/// what that fact may be used for, and it is `provisional` until the floor is fixed
+/// at release.
+public struct SupportStatement: Codable, Equatable {
+    public let minimumOS: String
+    public let status: SupportStatus
+    public let note: String
+
+    public init(minimumOS: String, status: SupportStatus, note: String) {
+        self.minimumOS = minimumOS
+        self.status = status
+        self.note = note
+    }
+
+    enum CodingKeys: String, CodingKey {
+        case minimumOS = "minimum_os"
+        case status
+        case note
+    }
+}
+
+/// The declared, typed manifest of what this client can render and measure.
+///
+/// It exists so that negotiation is a property of the **installed build** rather
+/// than of whatever the caller remembers to pass: a caller asks the package what it
+/// can do, and the package answers from one place. Adding a capability here without
+/// adding the code that executes it is the failure this type is meant to make
+/// visible, so every token below is justified in a comment beside it.
+public enum GowitCapabilities {
+
+    /// The serving protocol generation this client speaks.
+    public static let protocolMajor = 1
+
+    /// The build identity this client reports. Compiled in, not configured.
+    public static var rendererVersion: String { gowitVersion }
+
+    /// The operating-system floor, provisional (see `SupportStatus`).
+    public static let support = SupportStatement(
+        minimumOS: "iOS 15.0",
+        status: .provisional,
+        note: "The package's compiled deployment target. The supported-OS floor is a release-time "
+            + "decision and is not fixed by this build; three clients of one product currently "
+            + "compile to three different floors."
+    )
+
+    /// The capability vector for this build.
+    ///
+    /// Justification, token by token, so the manifest cannot drift from the code:
+    ///
+    /// - `primitive.image`, `primitive.text`, `primitive.container` — the declarative
+    ///   standard-ad components in `AdViews`.
+    /// - `primitive.entity_card` — `SponsoredProductView` and `SponsoredDisplayView`.
+    /// - `primitive.video` — the video stack (player manager, playback controller,
+    ///   observer, cache, configuration).
+    /// - `primitive.html_frame` — `HTMLAdDisplayView`. A LAYOUT boundary; see
+    ///   `isolation` for why that is not a security claim.
+    /// - `action.open_url`, `action.in_app_browser` — the redirect handler and
+    ///   `InAppBrowserView`.
+    /// - `media.vast` / `media.videoLifecycle` / `media.autoplay` — the VAST parser,
+    ///   validator and event tracker together with the player.
+    /// - `observation.root_impression`, `observation.click`, `observation.viewability`
+    ///   — the typed event vocabulary and the events endpoint. `observation.video_completion`
+    ///   is deliberately ABSENT: a VAST event tracker exists, but whether it reports
+    ///   completion under this contract's definition has not been measured, and a
+    ///   renderer without completion measurement may not advertise completion coverage.
+    /// - `isolation.sandboxed = false` — NOT MEASURED, and therefore false. The
+    ///   presence of an HTML display view is not evidence that it is constrained;
+    ///   a constrained WebView with restricted origins, navigation and storage is
+    ///   separate work. Declaring `false` is what makes an opaque-markup format
+    ///   refuse this client, which is the correct outcome.
+    public static var installed: RendererCapability {
+        RendererCapability(
+            protocolMajor: protocolMajor,
+            platform: .ios,
+            rendererVersion: rendererVersion,
+            primitives: [
+                CapabilityToken.Primitive.image,
+                CapabilityToken.Primitive.text,
+                CapabilityToken.Primitive.container,
+                CapabilityToken.Primitive.entityCard,
+                CapabilityToken.Primitive.video,
+                CapabilityToken.Primitive.htmlFrame
+            ],
+            actions: [
+                CapabilityToken.Action.openURL,
+                CapabilityToken.Action.inAppBrowser
+            ],
+            media: MediaCapability(videoLifecycle: true, autoplay: true, vast: true),
+            observation: [
+                CapabilityToken.Observation.rootImpression,
+                CapabilityToken.Observation.click,
+                CapabilityToken.Observation.viewability
+            ],
+            isolation: IsolationCapability(sandboxed: false)
+        )
+    }
+
+    /// The installed vector with the space actually available at request time.
+    public static func installed(in geometry: GeometryCapability) -> RendererCapability {
+        installed.withGeometry(geometry)
+    }
+
+    /// Encode the installed vector for transport. Absent collections stay absent:
+    /// `nil` must not be normalised to `[]`, because the two mean different things.
+    public static func encodedManifest() throws -> Data {
+        let encoder = JSONEncoder()
+        encoder.outputFormatting = [.sortedKeys]
+        return try encoder.encode(installed)
+    }
+}

--- a/Sources/Gowit/Capabilities/RendererCapability.swift
+++ b/Sources/Gowit/Capabilities/RendererCapability.swift
@@ -1,0 +1,190 @@
+import Foundation
+
+/// The platform a renderer runs on.
+public enum RendererPlatform: String, Codable, CaseIterable {
+    case web
+    case ios
+    case android
+}
+
+/// Playback capability, declared separately from the video **primitive** because
+/// parsing is not playing: a client can carry a VAST parser and still have no
+/// working player, and that state must be expressible.
+public struct MediaCapability: Codable, Equatable {
+    /// load, start, quartile, complete, plus muted, autoplay, background and retry.
+    public let videoLifecycle: Bool?
+    public let autoplay: Bool?
+    public let codecs: [String]?
+    /// Wrapper resolution and tracker integration. Parsing a VAST document does not set this.
+    public let vast: Bool?
+
+    public init(videoLifecycle: Bool? = nil, autoplay: Bool? = nil, codecs: [String]? = nil, vast: Bool? = nil) {
+        self.videoLifecycle = videoLifecycle
+        self.autoplay = autoplay
+        self.codecs = codecs
+        self.vast = vast
+    }
+
+    enum CodingKeys: String, CodingKey {
+        case videoLifecycle = "video_lifecycle"
+        case autoplay
+        case codecs
+        case vast
+    }
+}
+
+/// The ACTUAL space available at request time — distinct from a placement's logical
+/// outer opportunity and from a template region's own size. It is a property of the
+/// request, not of the installed build, which is why it is absent from the static
+/// manifest and supplied by `RendererCapability.withGeometry(_:)`.
+public struct GeometryCapability: Codable, Equatable {
+    public let availableWidth: Int?
+    public let availableHeight: Int?
+    /// Device pixel ratio. Asset pixels are checked against region x density.
+    public let density: Double?
+    public let heightMayChange: Bool?
+
+    public init(availableWidth: Int? = nil, availableHeight: Int? = nil, density: Double? = nil, heightMayChange: Bool? = nil) {
+        self.availableWidth = availableWidth
+        self.availableHeight = availableHeight
+        self.density = density
+        self.heightMayChange = heightMayChange
+    }
+
+    enum CodingKeys: String, CodingKey {
+        case availableWidth = "available_width"
+        case availableHeight = "available_height"
+        case density
+        case heightMayChange = "height_may_change"
+    }
+}
+
+/// What the runtime can actually ENFORCE around opaque markup.
+///
+/// Declared separately from `primitive.html_frame` because a frame is a LAYOUT
+/// boundary and a sandbox is a SECURITY boundary. A format whose content profile is
+/// opaque markup requires `sandboxed` and will refuse a client that only has the
+/// frame — which is the correct answer, not a defect.
+public struct IsolationCapability: Codable, Equatable {
+    public let sandboxed: Bool?
+    public let restrictedNavigation: Bool?
+    public let restrictedStorage: Bool?
+    public let bridgeVersion: Int?
+
+    public init(sandboxed: Bool? = nil, restrictedNavigation: Bool? = nil, restrictedStorage: Bool? = nil, bridgeVersion: Int? = nil) {
+        self.sandboxed = sandboxed
+        self.restrictedNavigation = restrictedNavigation
+        self.restrictedStorage = restrictedStorage
+        self.bridgeVersion = bridgeVersion
+    }
+
+    enum CodingKeys: String, CodingKey {
+        case sandboxed
+        case restrictedNavigation = "restricted_navigation"
+        case restrictedStorage = "restricted_storage"
+        case bridgeVersion = "bridge_version"
+    }
+}
+
+/// What this runtime DECLARES it can draw, do, play and observe.
+///
+/// The negotiation rule, in one place, so three decoders cannot disagree:
+///
+/// 1. The client sends its vector on the ad request. A vector is not a claim of
+///    support for anything it does not name.
+/// 2. The server evaluates one tuple per candidate and returns either a resolved
+///    render plan or a structured reason. It never returns a plan the vector cannot
+///    execute.
+/// 3. An ABSENT array or object means "declares nothing of this kind". It never
+///    means "declares everything" — which is why every collection here is
+///    `Optional` and `nil` is preserved through a round trip rather than
+///    normalised to empty.
+/// 4. An UNKNOWN TOKEN in a vector is ignored, so a newer client cannot be refused
+///    by an older server for saying more than it was asked.
+/// 5. An unknown FIELD in this envelope is ignored by both sides, so v1 stays
+///    additive. `Decodable` gives that for free; do not add a strict-key check.
+/// 6. `protocolMajor` is the one field whose mismatch is fatal in both directions.
+/// 7. NO VECTOR AT ALL is legal and means the legacy generation.
+public struct RendererCapability: Codable, Equatable {
+
+    /// The serving protocol generation this runtime speaks. An unknown major gets an
+    /// explicit `UNSUPPORTED_PROTOCOL_MAJOR`, never a best-effort render.
+    public let protocolMajor: Int
+    public let platform: RendererPlatform
+    /// The client build — distinct from `protocolMajor`, which is the wire generation.
+    public let rendererVersion: String
+
+    public let primitives: [String]?
+    public let actions: [String]?
+    public let media: MediaCapability?
+    public let observation: [String]?
+    public let geometry: GeometryCapability?
+    public let isolation: IsolationCapability?
+
+    public init(
+        protocolMajor: Int,
+        platform: RendererPlatform,
+        rendererVersion: String,
+        primitives: [String]? = nil,
+        actions: [String]? = nil,
+        media: MediaCapability? = nil,
+        observation: [String]? = nil,
+        geometry: GeometryCapability? = nil,
+        isolation: IsolationCapability? = nil
+    ) {
+        self.protocolMajor = protocolMajor
+        self.platform = platform
+        self.rendererVersion = rendererVersion
+        self.primitives = primitives
+        self.actions = actions
+        self.media = media
+        self.observation = observation
+        self.geometry = geometry
+        self.isolation = isolation
+    }
+
+    enum CodingKeys: String, CodingKey {
+        case protocolMajor = "protocol_major"
+        case platform
+        case rendererVersion = "renderer_version"
+        case primitives
+        case actions
+        case media
+        case observation
+        case geometry
+        case isolation
+    }
+
+    // MARK: - Negotiation
+
+    /// Whether this vector names `token`. Absence is the answer for an absent
+    /// collection: "declares nothing of this kind" is not "declares everything".
+    public func declares(_ token: String) -> Bool {
+        if primitives?.contains(token) == true { return true }
+        if actions?.contains(token) == true { return true }
+        if observation?.contains(token) == true { return true }
+        return false
+    }
+
+    /// The subset of `required` this vector does not declare, in the order asked.
+    /// An empty result means the variant is executable here.
+    public func missingCapabilities(from required: [String]) -> [String] {
+        required.filter { !declares($0) }
+    }
+
+    /// The same vector with request-time geometry attached. Geometry belongs to the
+    /// request, not to the installed build.
+    public func withGeometry(_ geometry: GeometryCapability) -> RendererCapability {
+        RendererCapability(
+            protocolMajor: protocolMajor,
+            platform: platform,
+            rendererVersion: rendererVersion,
+            primitives: primitives,
+            actions: actions,
+            media: media,
+            observation: observation,
+            geometry: geometry,
+            isolation: isolation
+        )
+    }
+}

--- a/Tests/gowit.swiftTests/CapabilityManifestTests.swift
+++ b/Tests/gowit.swiftTests/CapabilityManifestTests.swift
@@ -1,0 +1,154 @@
+import XCTest
+@testable import Gowit
+
+final class CapabilityManifestTests: XCTestCase {
+
+    /// The capability vector the contract lane froze for this client, verbatim.
+    ///
+    /// It is pinned here rather than fetched so that a change on either side is a
+    /// failing test in a diff someone reads, instead of a silent divergence between
+    /// what the client declares and what the server negotiates against.
+    private let frozenIOSVector = """
+    {
+      "protocol_major": 1,
+      "platform": "ios",
+      "renderer_version": "1.0.4",
+      "primitives": [
+        "primitive.image",
+        "primitive.text",
+        "primitive.container",
+        "primitive.entity_card",
+        "primitive.video",
+        "primitive.html_frame"
+      ],
+      "actions": [
+        "action.open_url",
+        "action.in_app_browser"
+      ],
+      "media": { "video_lifecycle": true, "autoplay": true, "vast": true },
+      "observation": [
+        "observation.root_impression",
+        "observation.click",
+        "observation.viewability"
+      ],
+      "isolation": { "sandboxed": false }
+    }
+    """
+
+    func testInstalledManifestMatchesFrozenContractVector() throws {
+        let encoded = try GowitCapabilities.encodedManifest()
+        let mine = try XCTUnwrap(JSONSerialization.jsonObject(with: encoded) as? NSDictionary)
+        let frozen = try XCTUnwrap(
+            JSONSerialization.jsonObject(with: Data(frozenIOSVector.utf8)) as? NSDictionary
+        )
+        XCTAssertEqual(mine, frozen, "The installed manifest drifted from the frozen ios-1.0.4 capability vector.")
+    }
+
+    func testFrozenVectorDecodesIntoTheTypedEnvelope() throws {
+        let decoded = try JSONDecoder().decode(RendererCapability.self, from: Data(frozenIOSVector.utf8))
+        XCTAssertEqual(decoded, GowitCapabilities.installed)
+        XCTAssertEqual(decoded.platform, .ios)
+        XCTAssertEqual(decoded.protocolMajor, 1)
+    }
+
+    func testRendererVersionIsTheCompiledBuildNotTheProtocol() {
+        XCTAssertEqual(GowitCapabilities.rendererVersion, gowitVersion)
+        XCTAssertNotEqual(GowitCapabilities.rendererVersion, String(GowitCapabilities.protocolMajor))
+    }
+
+    /// An absent collection means "declares nothing of this kind". Normalising it to
+    /// an empty array would lose nothing here, but normalising it to "everything" is
+    /// the mistake the contract names, and the way to be sure neither happens is that
+    /// `nil` survives a round trip.
+    func testAbsentCollectionsStayAbsent() throws {
+        let bare = RendererCapability(protocolMajor: 1, platform: .ios, rendererVersion: "0.0.1")
+        let data = try JSONEncoder().encode(bare)
+        let object = try XCTUnwrap(JSONSerialization.jsonObject(with: data) as? [String: Any])
+
+        XCTAssertNil(object["primitives"])
+        XCTAssertNil(object["observation"])
+        XCTAssertNil(object["isolation"])
+
+        let round = try JSONDecoder().decode(RendererCapability.self, from: data)
+        XCTAssertNil(round.primitives)
+        XCTAssertNil(round.observation)
+        XCTAssertFalse(round.declares(CapabilityToken.Primitive.image))
+    }
+
+    /// v1 stays additive: an unknown field must not make a decoder refuse a vector a
+    /// newer peer sent.
+    func testUnknownEnvelopeFieldIsIgnored() throws {
+        let json = """
+        {"protocol_major":1,"platform":"ios","renderer_version":"1.0.4","some_future_field":{"a":1}}
+        """
+        let decoded = try JSONDecoder().decode(RendererCapability.self, from: Data(json.utf8))
+        XCTAssertEqual(decoded.rendererVersion, "1.0.4")
+    }
+
+    /// A newer client saying more than it was asked must not be refused for it.
+    func testUnknownTokenIsCarriedNotRefused() throws {
+        let json = """
+        {"protocol_major":1,"platform":"ios","renderer_version":"9.9.9","primitives":["primitive.image","primitive.hologram"]}
+        """
+        let decoded = try JSONDecoder().decode(RendererCapability.self, from: Data(json.utf8))
+        XCTAssertTrue(decoded.declares("primitive.hologram"))
+        XCTAssertTrue(decoded.declares(CapabilityToken.Primitive.image))
+    }
+
+    func testMissingCapabilitiesNamesEveryMissingTokenInOrder() {
+        let vector = RendererCapability(
+            protocolMajor: 1,
+            platform: .ios,
+            rendererVersion: "1.0.4",
+            primitives: [CapabilityToken.Primitive.image]
+        )
+        let missing = vector.missingCapabilities(from: [
+            CapabilityToken.Primitive.container,
+            CapabilityToken.Primitive.image,
+            CapabilityToken.Primitive.entityCard
+        ])
+        XCTAssertEqual(missing, [CapabilityToken.Primitive.container, CapabilityToken.Primitive.entityCard])
+    }
+
+    /// The completion-coverage rule, enforced at the manifest rather than in prose: a
+    /// renderer that cannot measure completion may not advertise it.
+    func testVideoCompletionIsNotAdvertised() {
+        XCTAssertFalse(GowitCapabilities.installed.declares(CapabilityToken.Observation.videoCompletion))
+        XCTAssertTrue(GowitCapabilities.installed.declares(CapabilityToken.Observation.viewability))
+    }
+
+    /// The OS floor is a build fact published as a provisional statement, not a
+    /// support commitment.
+    func testSupportStatementIsProvisional() {
+        XCTAssertEqual(GowitCapabilities.support.status, .provisional)
+        XCTAssertEqual(GowitCapabilities.support.minimumOS, "iOS 15.0")
+    }
+
+    /// Geometry is a property of the request, so it is absent from the installed
+    /// manifest and present only once a caller supplies it.
+    func testGeometryIsRequestScoped() throws {
+        XCTAssertNil(GowitCapabilities.installed.geometry)
+        let sized = GowitCapabilities.installed(in: GeometryCapability(
+            availableWidth: 390, availableHeight: 120, density: 3.0, heightMayChange: false
+        ))
+        XCTAssertEqual(sized.geometry?.availableWidth, 390)
+        XCTAssertEqual(sized.primitives, GowitCapabilities.installed.primitives)
+
+        let object = try XCTUnwrap(
+            JSONSerialization.jsonObject(with: JSONEncoder().encode(sized)) as? [String: Any]
+        )
+        let geometry = try XCTUnwrap(object["geometry"] as? [String: Any])
+        XCTAssertEqual(geometry["available_width"] as? Int, 390)
+        XCTAssertEqual(geometry["height_may_change"] as? Bool, false)
+    }
+
+    func testRefusalEncodesTheContractSpelling() throws {
+        let refusal = CapabilityRefusal.missingCapability(["primitive.entity_card"])
+        let object = try XCTUnwrap(
+            JSONSerialization.jsonObject(with: JSONEncoder().encode(refusal)) as? [String: Any]
+        )
+        XCTAssertEqual(object["class"] as? String, "incompatible")
+        XCTAssertEqual(object["code"] as? String, "MISSING_CAPABILITY")
+        XCTAssertEqual(object["missing_capabilities"] as? [String], ["primitive.entity_card"])
+    }
+}

--- a/Tests/gowit.swiftTests/StandardAdRendererTests.swift
+++ b/Tests/gowit.swiftTests/StandardAdRendererTests.swift
@@ -1,0 +1,153 @@
+import XCTest
+@testable import Gowit
+@testable import AdViews
+
+final class StandardAdRendererTests: XCTestCase {
+
+    private func productAd(html: String? = nil, videoUrl: String? = nil) -> Ad {
+        Ad(
+            adId: "ad-1",
+            creativeId: 7,
+            imgUrl: "https://example.invalid/a.png",
+            videoUrl: videoUrl,
+            redirect: Redirect(url: "https://example.invalid/click", type: "product"),
+            advertiserId: "adv-1",
+            products: [
+                PromotedProduct(name: "Kettle", sku: "SKU-1", imageUrl: "https://example.invalid/p.png", rating: 4.5, price: 249.9)
+            ],
+            html: html
+        )
+    }
+
+    func testStandardProductAdResolvesToAnEntityCard() throws {
+        let plan = try XCTUnwrap(
+            StandardAdResolver.resolve(ad: productAd(), capability: GowitCapabilities.installed).get()
+        )
+        guard case .entityCard(let role, let children) = plan.root else {
+            return XCTFail("expected an entity card, got \(plan.root)")
+        }
+        XCTAssertEqual(role, .root)
+        XCTAssertEqual(plan.adId, "ad-1")
+        XCTAssertTrue(children.contains(.text(role: .headline, value: "Kettle")))
+        XCTAssertTrue(
+            children.contains(.text(role: .sponsorshipLabel, value: StandardAdResolver.sponsorshipLabel)),
+            "the disclosure is part of the tree, not a decoration the host may forget"
+        )
+    }
+
+    func testActionPrefersTheInAppBrowserThisRuntimeDeclares() throws {
+        let plan = try StandardAdResolver.resolve(ad: productAd(), capability: GowitCapabilities.installed).get()
+        XCTAssertEqual(plan.action?.token, CapabilityToken.Action.inAppBrowser)
+        XCTAssertEqual(plan.action?.url.absoluteString, "https://example.invalid/click")
+    }
+
+    /// D-50, enforced: opaque advertiser markup is REFUSED here and routed to the
+    /// isolated profile. It is never silently converted into an embedded browser view,
+    /// because that would trade native fidelity and measurement for a render nobody
+    /// asked for.
+    func testOpaqueMarkupIsRefusedNotSilentlyConvertedToAWebView() {
+        let result = StandardAdResolver.resolve(
+            ad: productAd(html: "<div onclick='steal()'>buy</div>"),
+            capability: GowitCapabilities.installed
+        )
+        guard case .failure(let refusal) = result else {
+            return XCTFail("markup must not resolve to a native plan")
+        }
+        XCTAssertEqual(refusal.code, .missingCapability)
+        XCTAssertEqual(refusal.refusalClass, .incompatible)
+        XCTAssertEqual(refusal.missingCapabilities, [StandardAdResolver.sandboxToken])
+    }
+
+    /// Declaring `primitive.html_frame` is a LAYOUT claim. Only `isolation.sandboxed`
+    /// is a security claim, and this build makes it false, so the frame alone does not
+    /// let markup through.
+    func testHTMLFrameAloneDoesNotAdmitMarkup() {
+        XCTAssertTrue(GowitCapabilities.installed.declares(CapabilityToken.Primitive.htmlFrame))
+        XCTAssertNotEqual(GowitCapabilities.installed.isolation?.sandboxed, true)
+    }
+
+    /// Parsing is not playing: a runtime with the video primitive but no lifecycle is
+    /// refused, and the refusal names the lifecycle it lacks.
+    func testVideoWithoutPlaybackLifecycleIsRefused() {
+        let parserOnly = RendererCapability(
+            protocolMajor: 1,
+            platform: .ios,
+            rendererVersion: "1.0.4",
+            primitives: [CapabilityToken.Primitive.video, CapabilityToken.Primitive.image, CapabilityToken.Primitive.text],
+            media: MediaCapability(videoLifecycle: false, vast: true)
+        )
+        let result = StandardAdResolver.resolve(
+            ad: productAd(videoUrl: "https://example.invalid/v.mp4"),
+            capability: parserOnly
+        )
+        guard case .failure(let refusal) = result else { return XCTFail("expected a refusal") }
+        XCTAssertEqual(refusal.missingCapabilities, ["media.video_lifecycle"])
+    }
+
+    func testMissingPrimitiveIsRefusedByNameRatherThanDegraded() {
+        let noCards = RendererCapability(
+            protocolMajor: 1,
+            platform: .ios,
+            rendererVersion: "1.0.4",
+            primitives: [CapabilityToken.Primitive.image, CapabilityToken.Primitive.text],
+            actions: [CapabilityToken.Action.openURL]
+        )
+        let result = StandardAdResolver.resolve(ad: productAd(), capability: noCards)
+        guard case .failure(let refusal) = result else { return XCTFail("expected a refusal") }
+        XCTAssertEqual(refusal.code, .missingCapability)
+        XCTAssertEqual(refusal.missingCapabilities, [CapabilityToken.Primitive.entityCard])
+    }
+
+    func testUnknownProtocolMajorIsFatalRatherThanBestEffort() {
+        let future = RendererCapability(protocolMajor: 99, platform: .ios, rendererVersion: "9.0.0")
+        let result = StandardAdResolver.resolve(ad: productAd(), capability: future)
+        guard case .failure(let refusal) = result else { return XCTFail("expected a refusal") }
+        XCTAssertEqual(refusal.code, .unsupportedProtocolMajor)
+    }
+
+    // MARK: - Lifecycle
+
+    /// The once-only rule, and the reason it is keyed on the ad rather than on the
+    /// view: a recycled cell must not double-count the ad it is leaving, and must not
+    /// swallow the impression of the ad it is arriving at.
+    func testExposureFiresOncePerIdentityAndAgainAfterReuse() {
+        var events: [AdRenderEvent] = []
+        let lifecycle = AdRenderLifecycle { events.append($0) }
+
+        lifecycle.mount(adID: "ad-1")
+        XCTAssertTrue(lifecycle.expose(adID: "ad-1"))
+        XCTAssertFalse(lifecycle.expose(adID: "ad-1"), "a second exposure of the same identity must not fire")
+
+        lifecycle.dispose()
+        lifecycle.mount(adID: "ad-2")
+        XCTAssertTrue(lifecycle.expose(adID: "ad-2"), "a recycled view showing a different ad must fire")
+
+        XCTAssertEqual(events, [
+            .mounted(adId: "ad-1"),
+            .exposed(adId: "ad-1"),
+            .disposed(adId: "ad-1"),
+            .mounted(adId: "ad-2"),
+            .exposed(adId: "ad-2")
+        ])
+    }
+
+    /// A refusal reports and draws nothing. It must not reach the exposure path — an
+    /// ad that was never rendered cannot have been seen.
+    func testARefusalNeverProducesAnExposure() {
+        var events: [AdRenderEvent] = []
+        let lifecycle = AdRenderLifecycle { events.append($0) }
+        lifecycle.refuse(.missingCapability([StandardAdResolver.sandboxToken]))
+
+        XCTAssertEqual(events.count, 1)
+        guard case .refused = events[0] else { return XCTFail("expected a refusal event") }
+    }
+
+    func testDisposeReleasesTheIdentitySoTheSameAdCanBeCountedOnARemount() {
+        var exposures = 0
+        let lifecycle = AdRenderLifecycle { if case .exposed = $0 { exposures += 1 } }
+        lifecycle.expose(adID: "ad-1")
+        lifecycle.dispose()
+        lifecycle.expose(adID: "ad-1")
+        XCTAssertEqual(exposures, 2, "a genuine remount after teardown is a new opportunity")
+    }
+}


### PR DESCRIPTION
## What this adds

Three things, on one branch, for the iOS half of the native SDK work.

**1. A build-and-test workflow.** The repository's only workflow lints on Linux and
compiles nothing, so the four test files under `Tests/` were never built by CI. One job
on a GitHub-hosted macOS image now builds the package, runs the tests and builds the
sample host application. An iOS build has nowhere else to run. The simulator destination
is resolved at run time rather than pinned, so a runner-image update does not become a
red build with a misleading reason.

**A finding that came with it:** *the tests did not compile at `main`.*
`Tests/gowit.swiftTests/VASTParserTests.swift:2` declares `@testable import AdViews`
while the test target in `Package.swift` depended only on `Gowit`, so the whole target
failed with `Unable to resolve module dependency: 'AdViews'` and nothing ran. That is a
one-line manifest fix (`fade6fe`) and it is the precondition for the workflow being worth
anything. It is exactly the class of defect a lint-only CI hides.

**2. A typed capability manifest** (`Sources/Gowit/Capabilities/`). The package now
answers what it can draw, do, play and observe from one place, so negotiation is a
property of the installed build rather than of whatever a caller remembers to pass.

- `RendererCapability` is the wire envelope. Absent collections stay absent, because
  "declares nothing of this kind" is not "declares everything"; unknown fields and
  unknown tokens are ignored rather than refused, so a newer peer is not turned away
  for saying more than it was asked; `protocol_major` is the one mismatch that is fatal
  in both directions.
- `CapabilityToken` carries the namespaced tokens (`primitive.*`, `action.*`,
  `observation.*`); the set is open by design.
- `GowitCapabilities.installed` is this build's vector, with every token justified in a
  comment beside it.
- Two absences are deliberate and pinned by tests. `observation.video_completion` is
  **not** advertised: a VAST tracker exists, but whether it reports completion under the
  contract's definition was never measured, and a renderer that cannot measure completion
  may not claim completion coverage. `isolation.sandboxed` is **false**: an HTML display
  view is a layout boundary and is not evidence of a constrained one.
- The OS floor is published as a **provisional** support statement. The deployment target
  is a build fact; what that fact may be used for is a release-time decision this build
  does not make.

**3. Declarative native components for standard ads** (`Sources/AdViews/Declarative/`)
and a sample host application (`Examples/GowitSampleApp/`).

- A bounded grammar — container, image, text, entity card — resolved against the
  capability vector *before* anything is drawn, so the renderer only executes a plan this
  runtime has already been proven able to run.
- Opaque advertiser markup is **refused** with `MISSING_CAPABILITY` naming
  `isolation.sandboxed` and routed to the isolated profile, rather than quietly drawn in
  an embedded browser view. Video on a runtime without a playback lifecycle is refused the
  same way, because parsing is not playing.
- An action carries a token and a URL and nothing that could name a host selector or a
  method, so an unfamiliar action name cannot reach arbitrary host functionality however
  it is spelled on the wire.
- The lifecycle reports mount, exposure, refusal and disposal separately, and keys the
  once-only exposure guard on the **ad's identity** rather than on the view's existence —
  a recycled cell must not double-count the ad it is leaving nor swallow the impression of
  the ad it is arriving at. A refusal draws nothing and never reaches the exposure path.
- The sample app renders one standard ad from a bundled fixture with **no network call**,
  so the run proves the renderer rather than the reachability of an ad server.

21 new tests join the 28 that exist: 49 total.

## Evidence — what was actually run

Xcode 26.6 (17F113), Swift 6.3.3, simulator iPhone 17 Pro on iOS 26.5, from clean derived
data.

| Gate | Command | Result |
|---|---|---|
| Package builds | `xcodebuild build -scheme Gowit-Package -destination 'platform=iOS Simulator,…'` | `** BUILD SUCCEEDED **` |
| Tests run | `xcodebuild test -scheme Gowit-Package …` | `Executed 49 tests, with 0 failures (0 unexpected)` — `** TEST SUCCEEDED **` |
| Sample app builds | `xcodebuild build -project Examples/GowitSampleApp/GowitSampleApp.xcodeproj -scheme GowitSampleApp …` | `** BUILD SUCCEEDED **` |
| Sample app launches | `xcrun simctl install` + `launch --console-pty` | `[gowit-sample] mounted fixture-ad-0001` then `[gowit-sample] exposed fixture-ad-0001` |

Per-suite: `AdManagerTests` 10, `CapabilityManifestTests` 11 (new), `GowitSDKTests` 15,
`StandardAdRendererTests` 10 (new), `VASTParserTests` 3. The three pre-existing suites pass
unchanged; nothing in them was edited.

**The limits of that evidence, stated plainly.** Physical-device proof is deferred, so a
simulator run is the whole of it. Nothing here demonstrates behaviour on real hardware —
not video playback, not memory under pressure, not backgrounding, not rotation on a device,
and not the OS floor, which is why the support statement is marked provisional rather than
committed. The image in the fixture points at an unreachable host on purpose, so the media
region draws its placeholder; that exercises the failure branch of the image primitive and
is not a rendering defect.

## Manifest alignment

`GowitCapabilities.installed` is pinned by
`CapabilityManifestTests.testInstalledManifestMatchesFrozenContractVector` against the
capability vector the contract lane froze for this client (`platform: ios`,
`renderer_version: 1.0.4`, six primitives, two actions, `media` with lifecycle/autoplay/vast,
three observation tokens, `isolation.sandboxed: false`). That lane's pull request is still
open, so **the manifest is to be aligned with the frozen vectors** once they merge: the test
holds the two together, and a change on either side becomes a failing test in a diff someone
reads rather than a silent divergence. `RefusalCode` likewise carries only the subset of the
platform's refusal vocabulary this client can raise locally.

## Inventory defect — recorded, not fixed

`README.md` instructs consumers to depend on
`https://github.com/gowittechnology/gowit-swift.git` (hyphen). **This repository is named
`gowit.swift` (dot).** Whether a redirect covers it was not tested. It is left exactly as it
is here, on purpose: it belongs to the inventory pass, not to this branch.

## Two things worth a reviewer's eye

- `AdManagerTests.testGetAdsWithoutConfiguration` and its neighbours make **real network
  calls** to `platform-stage.gowit.com` (a 403 is visible in the log). They pass because they
  assert *an* error is thrown, so they would also pass if the host were unreachable. They are
  not hermetic, and on a hosted runner that is an external dependency in CI. Not changed here
  — out of this branch's scope.
- The sample app's `.xcodeproj` uses a synchronized root group and a local package reference
  (`relativePath = ../..`), so adding a file to `Examples/GowitSampleApp/GowitSampleApp/`
  needs no project edit. Its scheme is committed under `xcshareddata` because auto-generated
  schemes land in gitignored `xcuserdata` and CI would not find one.
